### PR TITLE
Remove one reflection warning on XmlReader constructor

### DIFF
--- a/src/remus.clj
+++ b/src/remus.clj
@@ -51,7 +51,7 @@
 
 (defn parse-stream
   [^InputStream stream & [opt-rome]]
-  (let [{:keys [lenient encoding]} opt-rome
+  (let [{:keys [lenient ^String encoding]} opt-rome
         lenient (boolean lenient)]
     (reader->feed
      (XmlReader. ^InputStream stream lenient encoding))))


### PR DESCRIPTION
Fixing one reflection warning.

There are others remaining (use `lein do clean, check` to see them), they are more tricky to fix :-)