### PR TITLE
feat: add :allow-doctypes option to feed parsing

### DIFF
--- a/src/remus.clj
+++ b/src/remus.clj
@@ -15,6 +15,9 @@
 
   - `content-type`: a string meaning the MIME type of the feed, e.g. `application/rss`
     or something. When parsing a URL, it comes from the `Content-Type` header.
+
+  - `:allow-doctypes`: a boolean flag, if true, allows parsing feeds containing
+    DOCTYPE declarations (normally disallowed).
   "
   (:require
    [babashka.http-client :as client]
@@ -51,7 +54,7 @@
    (with-open [in (io/input-stream src)]
      (-> in
          (rome/make-reader opt-rome)
-         (rome/reader->feed)))))
+         (rome/reader->feed opt-rome)))))
 
 
 (defn ^:deprecated parse-stream

--- a/src/remus/rome.clj
+++ b/src/remus/rome.clj
@@ -52,8 +52,9 @@
 
 
 (defn reader->feed
-  [^XmlReader reader]
-  (let [input (new SyndFeedInput)
+  [^XmlReader reader & [{:keys [allow-doctypes]}]]
+  (let [input (doto (new SyndFeedInput)
+                (.setAllowDoctypes (boolean allow-doctypes)))
         ^SyndFeed feed (.build input reader)]
     (->clj feed)))
 


### PR DESCRIPTION
### Summary
This PR introduces a new `:allow-doctypes` option when parsing feeds. By default, DOCTYPE declarations are disallowed for safety reasons, but some feeds in the wild include them. With this change, consumers can explicitly opt-in to allowing it.

### Changes
- Added `:allow-doctypes` flag to opt-rome
- `SyndFeedInput` is now configured with `.setAllowDoctypes` when the flag is true
- Updated documentation to include the new option

### Motivation
Some feeds cannot be parsed without allowing DOCTYPE declarations. This change provides flexibility without changing default secure behavior.

Example feeds which don't get parsed if `:allow-doctypes` is `false`:
1. https://nakkaya.com/rss-feed
2. https://kriyative.github.io/rss/clojure.xml